### PR TITLE
add "--repl-port" command line option

### DIFF
--- a/chrome/content/server.js
+++ b/chrome/content/server.js
@@ -218,6 +218,8 @@ function setContextWindowType(windowType) {
 // ----------------------------------------------------------------------
 
 function log(msg) {
-    dump(msg + '\n');
+    if(! pref.getBoolPref('noLog')) {
+      dump(msg + '\n');
+    }
 }
 

--- a/components/CommandLine.js
+++ b/components/CommandLine.js
@@ -1,27 +1,27 @@
 /*
  * Copyright 2006-2011 by Massimiliano Mirra
- * 
+ *
  * This file is part of MozRepl.
- * 
+ *
  * MozRepl is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
  * Free Software Foundation; either version 3 of the License, or (at your
  * option) any later version.
- * 
+ *
  * MozRepl is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  * The interactive user interfaces in modified source and object code
  * versions of this program must display Appropriate Legal Notices, as
  * required under Section 5 of the GNU General Public License version 3.
- * 
+ *
  * Author: Massimiliano Mirra, <bard [at] hyperstruct [dot] net>
- *  
+ *
  */
 
 const Cc = Components.classes;
@@ -60,9 +60,13 @@ MozReplCommandLineHandler.prototype = {
             contextWindowType = cmdLine.handleFlagWithParam('repl-context', false);
         } catch(e) {}
 
-        if(start || contextWindowType) {
-            var port = Number(cmdLine.handleFlagWithParam('repl-port', false)) ||
-                srvPref.getIntPref('port');
+        var port;
+        try {
+            var port = parseInt(cmdLine.handleFlagWithParam('repl-port', false));
+        } catch(e) {}
+
+        if(start || port || contextWindowType) {
+            port = port || srvPref.getIntPref('port');
             var loopbackOnly = srvPref.getBoolPref('loopbackOnly');
 
             var service = Cc['@hyperstruct.net/mozlab/mozrepl;1']

--- a/components/CommandLine.js
+++ b/components/CommandLine.js
@@ -61,7 +61,7 @@ MozReplCommandLineHandler.prototype = {
         } catch(e) {}
 
         if(start || contextWindowType) {
-            var port = Number(cmdLine.handleFlagWithParam('repl', false)) ||
+            var port = Number(cmdLine.handleFlagWithParam('repl-port', false)) ||
                 srvPref.getIntPref('port');
             var loopbackOnly = srvPref.getBoolPref('loopbackOnly');
 
@@ -77,7 +77,8 @@ MozReplCommandLineHandler.prototype = {
     },
 
     helpInfo: ['-repl              Start REPL.\n',
-               '-repl-context      Start in the context gives as window type (see XUL windowtype attribute).\n'].join('')
+               '-repl-context      Start in the context gives as window type (see XUL windowtype attribute).\n',
+               '-repl-port <num>   Specify access port.\n'].join('')
             
 };
 

--- a/defaults/preferences/mozrepl.js
+++ b/defaults/preferences/mozrepl.js
@@ -6,3 +6,4 @@ pref("extensions.mozrepl.version", "");
 pref("extensions.mozrepl.defaultInteractor", "javascript");
 pref("extensions.mozrepl.interactor.javascript.printWelcome", true);
 pref("extensions.mozrepl.startingContext", "");
+pref("extensions.mozrepl.noLog", false);


### PR DESCRIPTION
This PR merges #43 ("Fixed port specification on command line") with minor tweaks 