### PR TITLE
disable addon signatures checks with tests running on Firefox >= 41

### DIFF
--- a/test/fixtures/test-prefs.json
+++ b/test/fixtures/test-prefs.json
@@ -1,5 +1,6 @@
 {
   "extensions.mozrepl.autoStart": true,
+  "xpinstall.signatures.required": false,
   "browser.tabs.remote.autostart": false,
   "browser.tabs.remote.autostart.1": false,
   "browser.tabs.remote.autostart.2": false

--- a/test/test-repl.js
+++ b/test/test-repl.js
@@ -42,7 +42,9 @@ beforeEach(function(done) {
   }
 
   mozrepl.on("connect", function() {
-    mozrepl.eval("content.location = 'http://localhost:8080';", done);
+    mozrepl.eval("content.location = 'http://localhost:8080';", function() {
+      setTimeout(done, 1500);
+    });
   });
   mozrepl.on("error", function() {
     if (retries > 0) {


### PR DESCRIPTION
This PR disable the newly added addon signature checks on Firefox >= 41 during tests