### PR TITLE
Fix deprecated octal literal syntax

### DIFF
--- a/chrome/content/repl.js
+++ b/chrome/content/repl.js
@@ -782,7 +782,7 @@ function evaluate(code) {
 
     var fos = Cc['@mozilla.org/network/file-output-stream;1']
         .createInstance(Ci.nsIFileOutputStream);
-    fos.init(_.TMP_FILE, 0x02 | 0x08 | 0x20, 0x180, 0);
+    fos.init(_.TMP_FILE, 0x02 | 0x08 | 0x20, 0o600, 0);
     var os = Cc['@mozilla.org/intl/converter-output-stream;1']
         .createInstance(Ci.nsIConverterOutputStream);
     os.init(fos, 'UTF-8', 0, 0x0000);

--- a/chrome/content/repl.js
+++ b/chrome/content/repl.js
@@ -782,8 +782,7 @@ function evaluate(code) {
 
     var fos = Cc['@mozilla.org/network/file-output-stream;1']
         .createInstance(Ci.nsIFileOutputStream);
-    fos.init(_.TMP_FILE, 0x02 | 0x08 | 0x20, 0600, 0);
-
+    fos.init(_.TMP_FILE, 0x02 | 0x08 | 0x20, 0x180, 0);
     var os = Cc['@mozilla.org/intl/converter-output-stream;1']
         .createInstance(Ci.nsIConverterOutputStream);
     os.init(fos, 'UTF-8', 0, 0x0000);


### PR DESCRIPTION
This PR fix the issue resolved by #60 using the new octal literal syntax
(because in octal the applied file permission are more recognizable)